### PR TITLE
Add berry firmness routes

### DIFF
--- a/app/components/tailwind-indicator.tsx
+++ b/app/components/tailwind-indicator.tsx
@@ -1,0 +1,15 @@
+/** Helpful component for Dev mode to display Tailwind media breakpoints query. */
+export function TailwindIndicator() {
+    if (process.env.NODE_ENV === "production") return null;
+
+    return (
+        <div className="fixed bottom-1 left-40 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-gray-800 p-3 font-mono text-xs text-white">
+            <div className="block sm:hidden">xs</div>
+            <div className="hidden sm:block md:hidden">sm</div>
+            <div className="hidden md:block lg:hidden">md</div>
+            <div className="hidden lg:block xl:hidden">lg</div>
+            <div className="hidden xl:block 2xl:hidden">xl</div>
+            <div className="hidden 2xl:block">2xl</div>
+        </div>
+    );
+}

--- a/app/components/ui/card.tsx
+++ b/app/components/ui/card.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+
+import { cn } from "@/lib/cn";
+
+const Card = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+    <div
+        ref={ref}
+        className={cn(
+            "rounded-lg border bg-card text-card-foreground shadow-sm",
+            className,
+        )}
+        {...props}
+    />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+    <div
+        ref={ref}
+        className={cn("flex flex-col space-y-1.5 p-6", className)}
+        {...props}
+    />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+    HTMLParagraphElement,
+    React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+    <h3
+        ref={ref}
+        className={cn(
+            "text-2xl font-semibold leading-none tracking-tight",
+            className,
+        )}
+        {...props}
+    />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+    HTMLParagraphElement,
+    React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+    <p
+        ref={ref}
+        className={cn("text-sm text-muted-foreground", className)}
+        {...props}
+    />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+    <div
+        ref={ref}
+        className={cn("flex items-center p-6 pt-0", className)}
+        {...props}
+    />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+    Card,
+    CardHeader,
+    CardFooter,
+    CardTitle,
+    CardDescription,
+    CardContent,
+};

--- a/app/components/ui/carousel.tsx
+++ b/app/components/ui/carousel.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import * as React from "react";
+import useEmblaCarousel, {
+    type UseEmblaCarouselType,
+} from "embla-carousel-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+
+import { cn } from "@/lib/cn";
+import { Button } from "@/components/ui/button";
+
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
+
+type CarouselProps = {
+    opts?: CarouselOptions;
+    plugins?: CarouselPlugin;
+    orientation?: "horizontal" | "vertical";
+    setApi?: (api: CarouselApi) => void;
+};
+
+type CarouselContextProps = {
+    carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+    api: ReturnType<typeof useEmblaCarousel>[1];
+    scrollPrev: () => void;
+    scrollNext: () => void;
+    canScrollPrev: boolean;
+    canScrollNext: boolean;
+} & CarouselProps;
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
+
+function useCarousel() {
+    const context = React.useContext(CarouselContext);
+
+    if (!context) {
+        throw new Error("useCarousel must be used within a <Carousel />");
+    }
+
+    return context;
+}
+
+const Carousel = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+    (
+        {
+            orientation = "horizontal",
+            opts,
+            setApi,
+            plugins,
+            className,
+            children,
+            ...props
+        },
+        ref,
+    ) => {
+        const [carouselRef, api] = useEmblaCarousel(
+            {
+                ...opts,
+                axis: orientation === "horizontal" ? "x" : "y",
+            },
+            plugins,
+        );
+        const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+        const [canScrollNext, setCanScrollNext] = React.useState(false);
+
+        const onSelect = React.useCallback((api: CarouselApi) => {
+            if (!api) {
+                return;
+            }
+
+            setCanScrollPrev(api.canScrollPrev());
+            setCanScrollNext(api.canScrollNext());
+        }, []);
+
+        const scrollPrev = React.useCallback(() => {
+            api?.scrollPrev();
+        }, [api]);
+
+        const scrollNext = React.useCallback(() => {
+            api?.scrollNext();
+        }, [api]);
+
+        const handleKeyDown = React.useCallback(
+            (event: React.KeyboardEvent<HTMLDivElement>) => {
+                if (event.key === "ArrowLeft") {
+                    event.preventDefault();
+                    scrollPrev();
+                } else if (event.key === "ArrowRight") {
+                    event.preventDefault();
+                    scrollNext();
+                }
+            },
+            [scrollPrev, scrollNext],
+        );
+
+        React.useEffect(() => {
+            if (!api || !setApi) {
+                return;
+            }
+
+            setApi(api);
+        }, [api, setApi]);
+
+        React.useEffect(() => {
+            if (!api) {
+                return;
+            }
+
+            onSelect(api);
+            api.on("reInit", onSelect);
+            api.on("select", onSelect);
+
+            return () => {
+                api?.off("select", onSelect);
+            };
+        }, [api, onSelect]);
+
+        return (
+            <CarouselContext.Provider
+                value={{
+                    carouselRef,
+                    api: api,
+                    opts,
+                    orientation:
+                        orientation ||
+                        (opts?.axis === "y" ? "vertical" : "horizontal"),
+                    scrollPrev,
+                    scrollNext,
+                    canScrollPrev,
+                    canScrollNext,
+                }}
+            >
+                <div
+                    ref={ref}
+                    onKeyDownCapture={handleKeyDown}
+                    className={cn("relative", className)}
+                    aria-roledescription="carousel"
+                    {...props}
+                >
+                    {children}
+                </div>
+            </CarouselContext.Provider>
+        );
+    },
+);
+Carousel.displayName = "Carousel";
+
+const CarouselContent = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+    const { carouselRef, orientation } = useCarousel();
+
+    return (
+        <div ref={carouselRef} className="overflow-hidden">
+            <div
+                ref={ref}
+                className={cn(
+                    "flex",
+                    orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+                    className,
+                )}
+                {...props}
+            />
+        </div>
+    );
+});
+CarouselContent.displayName = "CarouselContent";
+
+const CarouselItem = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+    const { orientation } = useCarousel();
+
+    return (
+        <div
+            ref={ref}
+            role="group"
+            aria-roledescription="slide"
+            className={cn(
+                "min-w-0 shrink-0 grow-0 basis-full",
+                orientation === "horizontal" ? "pl-4" : "pt-4",
+                className,
+            )}
+            {...props}
+        />
+    );
+});
+CarouselItem.displayName = "CarouselItem";
+
+const CarouselPrevious = React.forwardRef<
+    HTMLButtonElement,
+    React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+    const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+
+    return (
+        <Button
+            ref={ref}
+            variant={variant}
+            size={size}
+            className={cn(
+                "absolute  h-8 w-8 rounded-full",
+                orientation === "horizontal"
+                    ? "-left-12 top-1/2 -translate-y-1/2"
+                    : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+                className,
+            )}
+            disabled={!canScrollPrev}
+            onClick={scrollPrev}
+            {...props}
+        >
+            <ArrowLeft className="h-4 w-4" />
+            <span className="sr-only">Previous slide</span>
+        </Button>
+    );
+});
+CarouselPrevious.displayName = "CarouselPrevious";
+
+const CarouselNext = React.forwardRef<
+    HTMLButtonElement,
+    React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+    const { orientation, scrollNext, canScrollNext } = useCarousel();
+
+    return (
+        <Button
+            ref={ref}
+            variant={variant}
+            size={size}
+            className={cn(
+                "absolute h-8 w-8 rounded-full",
+                orientation === "horizontal"
+                    ? "-right-12 top-1/2 -translate-y-1/2"
+                    : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+                className,
+            )}
+            disabled={!canScrollNext}
+            onClick={scrollNext}
+            {...props}
+        >
+            <ArrowRight className="h-4 w-4" />
+            <span className="sr-only">Next slide</span>
+        </Button>
+    );
+});
+CarouselNext.displayName = "CarouselNext";
+
+export {
+    type CarouselApi,
+    Carousel,
+    CarouselContent,
+    CarouselItem,
+    CarouselPrevious,
+    CarouselNext,
+};

--- a/app/components/ui/dialog.tsx
+++ b/app/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/cn";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+        ref={ref}
+        className={cn(
+            "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            className,
+        )}
+        {...props}
+    />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+    <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+                className,
+            )}
+            {...props}
+        >
+            {children}
+            <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+                <X className="h-4 w-4" />
+                <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
+    </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn(
+            "flex flex-col space-y-1.5 text-center sm:text-left",
+            className,
+        )}
+        {...props}
+    />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn(
+            "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+            className,
+        )}
+        {...props}
+    />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Title
+        ref={ref}
+        className={cn(
+            "text-lg font-semibold leading-none tracking-tight",
+            className,
+        )}
+        {...props}
+    />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Description
+        ref={ref}
+        className={cn("text-sm text-muted-foreground", className)}
+        {...props}
+    />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+    Dialog,
+    DialogPortal,
+    DialogOverlay,
+    DialogClose,
+    DialogTrigger,
+    DialogContent,
+    DialogHeader,
+    DialogFooter,
+    DialogTitle,
+    DialogDescription,
+};

--- a/app/features/poke-berry-firmness/api/get-firmness.ts
+++ b/app/features/poke-berry-firmness/api/get-firmness.ts
@@ -1,0 +1,22 @@
+import { queryOptions } from "@tanstack/react-query";
+import { berryFirmnessZ, type BerryFirmnessT } from "../types";
+import berryFirmnessKeys from "./keys";
+
+export async function getFirmness({
+    firmnessId,
+}: { firmnessId: number | string }): Promise<BerryFirmnessT> {
+    const url = `https://pokeapi.co/api/v2/berry-firmness/${firmnessId}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}`);
+    }
+    const data = await response.json();
+    return berryFirmnessZ.parse(data);
+}
+
+export const getBerryFirmnessQueryOptions = (firmnessId: number | string) => {
+    return queryOptions({
+        queryKey: berryFirmnessKeys.detail(firmnessId),
+        queryFn: () => getFirmness({ firmnessId }),
+    });
+};

--- a/app/features/poke-berry-firmness/api/keys.ts
+++ b/app/features/poke-berry-firmness/api/keys.ts
@@ -1,0 +1,7 @@
+const berryFirmnessKeys = {
+    all: ["berry-firmness"] as const,
+    detail: (berryFirmnessId: number | string) =>
+        [...berryFirmnessKeys.all, berryFirmnessId] as const,
+} as const;
+
+export default berryFirmnessKeys;

--- a/app/features/poke-berry-firmness/api/list-firmness.ts
+++ b/app/features/poke-berry-firmness/api/list-firmness.ts
@@ -3,7 +3,7 @@ import { berryFirmnessListZ, type BerryFirmnessListT } from "../types";
 import berryFirmnessKeys from "./keys";
 import { getOffsetParam } from "@/lib/offset-parsing";
 
-export async function getFirmness({
+export async function getFirmnessList({
     offset,
     limit = 20,
 }: { offset: number; limit?: number }): Promise<BerryFirmnessListT> {
@@ -23,7 +23,7 @@ export async function getFirmness({
 export const getBerryFirmnessInfiniteQueryOptions = infiniteQueryOptions({
     queryKey: berryFirmnessKeys.all,
     queryFn: ({ pageParam = 0 }) => {
-        return getFirmness({ offset: pageParam as number });
+        return getFirmnessList({ offset: pageParam as number });
     },
     getNextPageParam: (lastPage) => {
         if (!lastPage.next) {

--- a/app/features/poke-berry-firmness/api/list-firmness.ts
+++ b/app/features/poke-berry-firmness/api/list-firmness.ts
@@ -1,0 +1,36 @@
+import { infiniteQueryOptions } from "@tanstack/react-query";
+import { berryFirmnessListZ, type BerryFirmnessListT } from "../types";
+import berryFirmnessKeys from "./keys";
+import { getOffsetParam } from "@/lib/offset-parsing";
+
+export async function getFirmness({
+    offset,
+    limit = 20,
+}: { offset: number; limit?: number }): Promise<BerryFirmnessListT> {
+    const searchParams = new URLSearchParams({
+        offset: String(offset),
+        limit: String(limit),
+    });
+    const url = `https://pokeapi.co/api/v2/berry-firmness?${searchParams.toString()}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}`);
+    }
+    const data = await response.json();
+    return berryFirmnessListZ.parse(data);
+}
+
+export const getBerryFirmnessInfiniteQueryOptions = infiniteQueryOptions({
+    queryKey: berryFirmnessKeys.all,
+    queryFn: ({ pageParam = 0 }) => {
+        return getFirmness({ offset: pageParam as number });
+    },
+    getNextPageParam: (lastPage) => {
+        if (!lastPage.next) {
+            // no more pages
+            return undefined;
+        }
+        return getOffsetParam(lastPage.next);
+    },
+    initialPageParam: 0,
+});

--- a/app/features/poke-berry-firmness/components/berry-ref-card.tsx
+++ b/app/features/poke-berry-firmness/components/berry-ref-card.tsx
@@ -1,0 +1,46 @@
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
+import type { BerryRefT, PokeBerryT } from "@/features/poke-berry/types";
+import Berry from "@/features/poke-berry/components/berry-detail";
+import toProperCase from "@/lib/to-proper";
+import { Button } from "@/components/ui/button";
+import { Link } from "@tanstack/react-router";
+
+export default function BerryCard({
+    berry,
+    firmnessName,
+}: { berry: BerryRefT; firmnessName: string }) {
+    const properFirmnessName = toProperCase(firmnessName);
+    // cheating the types here because I know what im doing
+    return (
+        <Berry berry={berry as unknown as PokeBerryT}>
+            <Card>
+                <CardHeader>
+                    <CardTitle>
+                        <Berry.Detail name="name" />
+                    </CardTitle>
+                    <CardDescription>
+                        One of the berries of the {properFirmnessName} firmness
+                        category.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <Berry.Image />
+                    <Button asChild variant="link">
+                        <Link
+                            to="/berry/$berryId"
+                            params={{ berryId: berry.name }}
+                        >
+                            View Details
+                        </Link>
+                    </Button>
+                </CardContent>
+            </Card>
+        </Berry>
+    );
+}

--- a/app/features/poke-berry-firmness/components/firmness-berry-carousel.tsx
+++ b/app/features/poke-berry-firmness/components/firmness-berry-carousel.tsx
@@ -1,0 +1,52 @@
+import {
+    Carousel,
+    CarouselContent,
+    CarouselItem,
+    CarouselNext,
+    CarouselPrevious,
+} from "@/components/ui/carousel";
+import type { BerryFirmnessT } from "../types";
+import { cn } from "@/lib/cn";
+import Autoplay from "embla-carousel-autoplay";
+import React from "react";
+import BerryCard from "./berry-ref-card";
+
+export type FirmnessBerryCarouselProps = {
+    firmness: BerryFirmnessT;
+    className?: string;
+};
+export default function FirmnessBerryCarousel({
+    firmness: { berries, name },
+    className,
+}: FirmnessBerryCarouselProps) {
+    const plugin = React.useRef(
+        Autoplay({ delay: 2000, stopOnInteraction: true }),
+    );
+    return (
+        <div className={cn("justify-center flex", className)}>
+            <Carousel
+                plugins={[plugin.current]}
+                className="w-full max-w-xs"
+                onMouseEnter={plugin.current.stop}
+                onMouseLeave={plugin.current.reset}
+                opts={{
+                    loop: true,
+                    align: "center",
+                }}
+            >
+                <CarouselContent>
+                    {berries.map((berry) => (
+                        <CarouselItem
+                            key={berry.name}
+                            className="basis-full lg:basis-1/2"
+                        >
+                            <BerryCard firmnessName={name} berry={berry} />
+                        </CarouselItem>
+                    ))}
+                </CarouselContent>
+                <CarouselPrevious />
+                <CarouselNext />
+            </Carousel>
+        </div>
+    );
+}

--- a/app/features/poke-berry-firmness/components/firmness-grid.tsx
+++ b/app/features/poke-berry-firmness/components/firmness-grid.tsx
@@ -1,15 +1,24 @@
 import useBerryFirmnessInfiniteQuery from "../hooks/use-list-berry-firmness";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
-
 import type { BerryFirmnessRefT } from "../types";
 import { cn } from "@/lib/cn";
 import { Button } from "@/components/ui/button";
 import { Link } from "@tanstack/react-router";
+import type React from "react";
 
+type LinkProps = React.ComponentProps<typeof Link>;
 export interface FirmnessGridProps {
     className?: string;
+    to: LinkProps["to"];
+    mask?: (val: string | number) => LinkProps["mask"];
+    paramName: string;
 }
-export default function FirmnessGrid({ className }: FirmnessGridProps) {
+export default function FirmnessGrid({
+    className,
+    to,
+    mask,
+    paramName,
+}: FirmnessGridProps) {
     const berryFirmnessInfQuery = useBerryFirmnessInfiniteQuery();
 
     const berryFirmnessPages =
@@ -29,9 +38,10 @@ export default function FirmnessGrid({ className }: FirmnessGridProps) {
                     className="h-full w-full"
                 >
                     <Link
-                        to="/berry/firmness/$firmnessId"
-                        params={{ firmnessId: berryFirmness.name }}
+                        to={to}
+                        params={{ [paramName]: berryFirmness.name }}
                         preload="intent"
+                        mask={mask ? mask(berryFirmness.name) : undefined}
                     >
                         <BerryFirmnessCard berryFirmness={berryFirmness} />
                     </Link>

--- a/app/features/poke-berry-firmness/components/firmness-grid.tsx
+++ b/app/features/poke-berry-firmness/components/firmness-grid.tsx
@@ -1,0 +1,56 @@
+import useBerryFirmnessInfiniteQuery from "../hooks/use-list-berry-firmness";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+
+import type { BerryFirmnessRefT } from "../types";
+import { cn } from "@/lib/cn";
+import { Button } from "@/components/ui/button";
+import { Link } from "@tanstack/react-router";
+
+export interface FirmnessGridProps {
+    className?: string;
+}
+export default function FirmnessGrid({ className }: FirmnessGridProps) {
+    const berryFirmnessInfQuery = useBerryFirmnessInfiniteQuery();
+
+    const berryFirmnessPages =
+        berryFirmnessInfQuery.data?.pages.flatMap((val) => val.results) ?? [];
+    return (
+        <div
+            className={cn(
+                "grid grid-cols-1 md:grid-cols-2 gap-4 place-items-center mx-24",
+                className,
+            )}
+        >
+            {berryFirmnessPages.map((berryFirmness) => (
+                <Button
+                    asChild
+                    variant="link"
+                    key={berryFirmness.name}
+                    className="h-full w-full"
+                >
+                    <Link
+                        to="/berry/firmness/$firmnessId"
+                        params={{ firmnessId: berryFirmness.name }}
+                        preload="intent"
+                    >
+                        <BerryFirmnessCard berryFirmness={berryFirmness} />
+                    </Link>
+                </Button>
+            ))}
+        </div>
+    );
+}
+
+function BerryFirmnessCard({
+    berryFirmness,
+}: { berryFirmness: BerryFirmnessRefT }) {
+    return (
+        <Card className="w-full h-full">
+            <CardHeader>
+                <CardTitle className="text-center uppercase">
+                    {berryFirmness.name}
+                </CardTitle>
+            </CardHeader>
+        </Card>
+    );
+}

--- a/app/features/poke-berry-firmness/hooks/use-berry-firmness.tsx
+++ b/app/features/poke-berry-firmness/hooks/use-berry-firmness.tsx
@@ -1,0 +1,23 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getBerryFirmnessQueryOptions } from "@/features/poke-berry-firmness/api/get-firmness";
+import type berryFirmnessKeys from "../api/keys";
+import type { ExtraQueryOptionsT } from "@/types/api";
+import type { BerryFirmnessT } from "../types";
+
+type BerryFirmnessKey = typeof berryFirmnessKeys;
+
+type BerryFirmnessQueryKey = ReturnType<BerryFirmnessKey["detail"]>;
+
+export interface useBerryFirmnessQueryProps
+    extends ExtraQueryOptionsT<BerryFirmnessT, BerryFirmnessQueryKey> {
+    firmnessId: number | string;
+}
+export default function useBerryFirmnessQuery({
+    firmnessId,
+    ...options
+}: useBerryFirmnessQueryProps) {
+    return useSuspenseQuery({
+        ...getBerryFirmnessQueryOptions(firmnessId),
+        ...options,
+    });
+}

--- a/app/features/poke-berry-firmness/hooks/use-list-berry-firmness.tsx
+++ b/app/features/poke-berry-firmness/hooks/use-list-berry-firmness.tsx
@@ -9,13 +9,12 @@ type BerryFirmnessKey = typeof berryFirmnessKeys;
 type BerryFirmnessQueryKey = BerryFirmnessKey["all"];
 
 export interface useBerryFirmnessInfiniteQueryProps
-    extends ExtraInfiniteQueryOptionsT<
-        BerryFirmnessRefT,
-        BerryFirmnessQueryKey
+    extends Partial<
+        ExtraInfiniteQueryOptionsT<BerryFirmnessRefT, BerryFirmnessQueryKey>
     > {}
 export default function useBerryFirmnessInfiniteQuery({
     ...options
-}: useBerryFirmnessInfiniteQueryProps) {
+}: useBerryFirmnessInfiniteQueryProps = {}) {
     return useSuspenseInfiniteQuery({
         ...getBerryFirmnessInfiniteQueryOptions,
         ...options,

--- a/app/features/poke-berry-firmness/hooks/use-list-berry-firmness.tsx
+++ b/app/features/poke-berry-firmness/hooks/use-list-berry-firmness.tsx
@@ -1,0 +1,23 @@
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import type berryFirmnessKeys from "../api/keys";
+import type { ExtraInfiniteQueryOptionsT } from "@/types/api";
+import type { BerryFirmnessRefT } from "../types";
+import { getBerryFirmnessInfiniteQueryOptions } from "../api/list-firmness";
+
+type BerryFirmnessKey = typeof berryFirmnessKeys;
+
+type BerryFirmnessQueryKey = BerryFirmnessKey["all"];
+
+export interface useBerryFirmnessInfiniteQueryProps
+    extends ExtraInfiniteQueryOptionsT<
+        BerryFirmnessRefT,
+        BerryFirmnessQueryKey
+    > {}
+export default function useBerryFirmnessInfiniteQuery({
+    ...options
+}: useBerryFirmnessInfiniteQueryProps) {
+    return useSuspenseInfiniteQuery({
+        ...getBerryFirmnessInfiniteQueryOptions,
+        ...options,
+    });
+}

--- a/app/features/poke-berry-firmness/types.ts
+++ b/app/features/poke-berry-firmness/types.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import {
+    type PokeExactEndpoint,
+    pokeExactEndpointZ,
+    type PokePaginationResult,
+    pokePaginationResultZ,
+} from "@/types/api";
+import type { BerryRefT } from "../poke-berry/types";
+
+export type BerryFirmnessRefT = {
+    name: string;
+    url: PokeExactEndpoint<"berry-firmness">;
+};
+
+export type BerryFirmnessT = {
+    berries: BerryRefT[];
+    id: number;
+    name: string;
+};
+
+export type BerryFirmnessListT = PokePaginationResult<
+    BerryFirmnessRefT,
+    "berry-firmness"
+>;
+
+export const berryFirmnessRefZ = z.object({
+    name: z.string(),
+    url: pokeExactEndpointZ("berry-firmness"),
+}) satisfies z.ZodType<BerryFirmnessRefT>;
+
+export const berryFirmnessZ = z.object({
+    berries: z.array(
+        z.object({
+            url: pokeExactEndpointZ("berry"),
+            name: z.string(),
+        }),
+    ),
+    id: z.number(),
+    name: z.string(),
+}) satisfies z.ZodType<BerryFirmnessT>;
+
+export const berryFirmnessListZ = pokePaginationResultZ(
+    berryFirmnessRefZ,
+    "berry-firmness",
+);

--- a/app/features/poke-berry/api/berry-images.ts
+++ b/app/features/poke-berry/api/berry-images.ts
@@ -27,6 +27,7 @@ import lansatBerry from "pokemon-sprites/sprites/items/berries/lansat-berry.png"
 import leppaBerry from "pokemon-sprites/sprites/items/berries/leppa-berry.png";
 import liechiBerry from "pokemon-sprites/sprites/items/berries/liechi-berry.png";
 import lumBerry from "pokemon-sprites/sprites/items/berries/lum-berry.png";
+import magoBerry from "pokemon-sprites/sprites/items/berries/mago-berry.png";
 import magostBerry from "pokemon-sprites/sprites/items/berries/magost-berry.png";
 import micleBerry from "pokemon-sprites/sprites/items/berries/micle-berry.png";
 import nanabBerry from "pokemon-sprites/sprites/items/berries/nanab-berry.png";
@@ -88,6 +89,7 @@ export default {
     leppa: leppaBerry,
     liechi: liechiBerry,
     lum: lumBerry,
+    mago: magoBerry,
     magost: magostBerry,
     micle: micleBerry,
     nanab: nanabBerry,
@@ -119,10 +121,3 @@ export default {
     wiki: wikiBerry,
     yache: yacheBerry,
 } as const;
-
-export async function importBerryImage(berryId: string): Promise<string> {
-    const berryImage = await import(
-        `pokemon-sprites/sprites/items/berries/${berryId}-berry.png`
-    );
-    return berryImage.default;
-}

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -13,8 +13,11 @@
 import { Route as rootRoute } from './routes/__root'
 import { Route as IndexImport } from './routes/index'
 import { Route as berryBerryImport } from './routes/(berry)/berry'
+import { Route as BerryFirmnessIndexImport } from './routes/berry_/firmness.index'
 import { Route as berryBerryIndexImport } from './routes/(berry)/berry.index'
+import { Route as BerryFirmnessFirmnessIdImport } from './routes/berry_/firmness.$firmnessId'
 import { Route as berryBerryBerryIdImport } from './routes/(berry)/berry.$berryId'
+import { Route as BerryFirmnessFirmnessIdModalImport } from './routes/berry_/firmness.$firmnessId_.modal'
 
 // Create/Update Routes
 
@@ -28,15 +31,31 @@ const berryBerryRoute = berryBerryImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
+const BerryFirmnessIndexRoute = BerryFirmnessIndexImport.update({
+  path: '/berry/firmness/',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const berryBerryIndexRoute = berryBerryIndexImport.update({
   path: '/',
   getParentRoute: () => berryBerryRoute,
+} as any)
+
+const BerryFirmnessFirmnessIdRoute = BerryFirmnessFirmnessIdImport.update({
+  path: '/berry/firmness/$firmnessId',
+  getParentRoute: () => rootRoute,
 } as any)
 
 const berryBerryBerryIdRoute = berryBerryBerryIdImport.update({
   path: '/$berryId',
   getParentRoute: () => berryBerryRoute,
 } as any)
+
+const BerryFirmnessFirmnessIdModalRoute =
+  BerryFirmnessFirmnessIdModalImport.update({
+    path: '/berry/firmness/$firmnessId/modal',
+    getParentRoute: () => rootRoute,
+  } as any)
 
 // Populate the FileRoutesByPath interface
 
@@ -63,12 +82,33 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof berryBerryBerryIdImport
       parentRoute: typeof berryBerryImport
     }
+    '/berry/firmness/$firmnessId': {
+      id: '/berry/firmness/$firmnessId'
+      path: '/berry/firmness/$firmnessId'
+      fullPath: '/berry/firmness/$firmnessId'
+      preLoaderRoute: typeof BerryFirmnessFirmnessIdImport
+      parentRoute: typeof rootRoute
+    }
     '/(berry)/berry/': {
       id: '/berry/'
       path: '/'
       fullPath: '/berry/'
       preLoaderRoute: typeof berryBerryIndexImport
       parentRoute: typeof berryBerryImport
+    }
+    '/berry/firmness/': {
+      id: '/berry/firmness/'
+      path: '/berry/firmness'
+      fullPath: '/berry/firmness'
+      preLoaderRoute: typeof BerryFirmnessIndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/berry/firmness/$firmnessId/modal': {
+      id: '/berry/firmness/$firmnessId/modal'
+      path: '/berry/firmness/$firmnessId/modal'
+      fullPath: '/berry/firmness/$firmnessId/modal'
+      preLoaderRoute: typeof BerryFirmnessFirmnessIdModalImport
+      parentRoute: typeof rootRoute
     }
   }
 }
@@ -93,13 +133,19 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/berry': typeof berryBerryRouteWithChildren
   '/berry/$berryId': typeof berryBerryBerryIdRoute
+  '/berry/firmness/$firmnessId': typeof BerryFirmnessFirmnessIdRoute
   '/berry/': typeof berryBerryIndexRoute
+  '/berry/firmness': typeof BerryFirmnessIndexRoute
+  '/berry/firmness/$firmnessId/modal': typeof BerryFirmnessFirmnessIdModalRoute
 }
 
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/berry/$berryId': typeof berryBerryBerryIdRoute
+  '/berry/firmness/$firmnessId': typeof BerryFirmnessFirmnessIdRoute
   '/berry': typeof berryBerryIndexRoute
+  '/berry/firmness': typeof BerryFirmnessIndexRoute
+  '/berry/firmness/$firmnessId/modal': typeof BerryFirmnessFirmnessIdModalRoute
 }
 
 export interface FileRoutesById {
@@ -107,26 +153,56 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/berry': typeof berryBerryRouteWithChildren
   '/berry/$berryId': typeof berryBerryBerryIdRoute
+  '/berry/firmness/$firmnessId': typeof BerryFirmnessFirmnessIdRoute
   '/berry/': typeof berryBerryIndexRoute
+  '/berry/firmness/': typeof BerryFirmnessIndexRoute
+  '/berry/firmness/$firmnessId/modal': typeof BerryFirmnessFirmnessIdModalRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/berry' | '/berry/$berryId' | '/berry/'
+  fullPaths:
+    | '/'
+    | '/berry'
+    | '/berry/$berryId'
+    | '/berry/firmness/$firmnessId'
+    | '/berry/'
+    | '/berry/firmness'
+    | '/berry/firmness/$firmnessId/modal'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/berry/$berryId' | '/berry'
-  id: '__root__' | '/' | '/berry' | '/berry/$berryId' | '/berry/'
+  to:
+    | '/'
+    | '/berry/$berryId'
+    | '/berry/firmness/$firmnessId'
+    | '/berry'
+    | '/berry/firmness'
+    | '/berry/firmness/$firmnessId/modal'
+  id:
+    | '__root__'
+    | '/'
+    | '/berry'
+    | '/berry/$berryId'
+    | '/berry/firmness/$firmnessId'
+    | '/berry/'
+    | '/berry/firmness/'
+    | '/berry/firmness/$firmnessId/modal'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   berryBerryRoute: typeof berryBerryRouteWithChildren
+  BerryFirmnessFirmnessIdRoute: typeof BerryFirmnessFirmnessIdRoute
+  BerryFirmnessIndexRoute: typeof BerryFirmnessIndexRoute
+  BerryFirmnessFirmnessIdModalRoute: typeof BerryFirmnessFirmnessIdModalRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   berryBerryRoute: berryBerryRouteWithChildren,
+  BerryFirmnessFirmnessIdRoute: BerryFirmnessFirmnessIdRoute,
+  BerryFirmnessIndexRoute: BerryFirmnessIndexRoute,
+  BerryFirmnessFirmnessIdModalRoute: BerryFirmnessFirmnessIdModalRoute,
 }
 
 export const routeTree = rootRoute
@@ -142,7 +218,10 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/",
-        "/berry"
+        "/berry",
+        "/berry/firmness/$firmnessId",
+        "/berry/firmness/",
+        "/berry/firmness/$firmnessId/modal"
       ]
     },
     "/": {
@@ -159,9 +238,18 @@ export const routeTree = rootRoute
       "filePath": "(berry)/berry.$berryId.tsx",
       "parent": "/berry"
     },
+    "/berry/firmness/$firmnessId": {
+      "filePath": "berry_/firmness.$firmnessId.tsx"
+    },
     "/berry/": {
       "filePath": "(berry)/berry.index.tsx",
       "parent": "/berry"
+    },
+    "/berry/firmness/": {
+      "filePath": "berry_/firmness.index.tsx"
+    },
+    "/berry/firmness/$firmnessId/modal": {
+      "filePath": "berry_/firmness.$firmnessId_.modal.tsx"
     }
   }
 }

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -11,6 +11,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import "@/global.css";
 import { siteConfig } from "@/config/site";
 import { Header } from "@/components/header";
+import { TailwindIndicator } from "@/components/tailwind-indicator";
 
 export const Route = createRootRouteWithContext<{
     queryClient: QueryClient;
@@ -75,6 +76,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
                 <React.Suspense>
                     <RouterDevtools />
                 </React.Suspense>
+                <TailwindIndicator />
                 <Scripts />
             </Body>
         </Html>

--- a/app/routes/berry_/firmness.$firmnessId.tsx
+++ b/app/routes/berry_/firmness.$firmnessId.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/berry/firmness/$firmnessId")({
+    component: () => <div>Hello /berry/firmness/$firmnessId!</div>,
+});

--- a/app/routes/berry_/firmness.$firmnessId.tsx
+++ b/app/routes/berry_/firmness.$firmnessId.tsx
@@ -1,5 +1,27 @@
+import { TypographyH2 } from "@/components/typography/headings";
+import { getBerryFirmnessQueryOptions } from "@/features/poke-berry-firmness/api/get-firmness";
+import FirmnessBerryCarousel from "@/features/poke-berry-firmness/components/firmness-berry-carousel";
+import useBerryFirmnessQuery from "@/features/poke-berry-firmness/hooks/use-berry-firmness";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/berry/firmness/$firmnessId")({
-    component: () => <div>Hello /berry/firmness/$firmnessId!</div>,
+    loader: ({ context: { queryClient }, params: { firmnessId } }) => {
+        queryClient.ensureQueryData(getBerryFirmnessQueryOptions(firmnessId));
+    },
+    component: () => <BerryFirmnessDetails />,
 });
+
+function BerryFirmnessDetails() {
+    const { firmnessId } = Route.useParams();
+    const berryQuery = useBerryFirmnessQuery({ firmnessId });
+    return (
+        <main className="flex flex-col mx-32 justify-center">
+            <TypographyH2>
+                Berries of{" "}
+                <span className="capitalize">{berryQuery.data.name}</span>{" "}
+                Firmness
+            </TypographyH2>
+            <FirmnessBerryCarousel firmness={berryQuery.data} />
+        </main>
+    );
+}

--- a/app/routes/berry_/firmness.$firmnessId_.modal.tsx
+++ b/app/routes/berry_/firmness.$firmnessId_.modal.tsx
@@ -1,0 +1,48 @@
+import { getBerryFirmnessQueryOptions } from "@/features/poke-berry-firmness/api/get-firmness";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+    Dialog,
+    DialogContent,
+    DialogOverlay,
+    DialogPortal,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import useBerryFirmnessQuery from "@/features/poke-berry-firmness/hooks/use-berry-firmness";
+
+export const Route = createFileRoute("/berry/firmness/$firmnessId/modal")({
+    loader: ({ context: { queryClient }, params: { firmnessId } }) =>
+        queryClient.ensureQueryData(getBerryFirmnessQueryOptions(firmnessId)),
+    component: () => <BerryFirmnessModal />,
+});
+
+function BerryFirmnessModal() {
+    const { firmnessId } = Route.useParams();
+    const berryFirmnessQuery = useBerryFirmnessQuery({ firmnessId });
+    const navigate = useNavigate();
+    return (
+        <Dialog
+            open
+            onOpenChange={(isOpen) => {
+                if (!isOpen) {
+                    navigate({ to: "/berry/firmness" });
+                }
+            }}
+        >
+            <DialogPortal>
+                <DialogOverlay />
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle className="capitalize">
+                            {berryFirmnessQuery.data.name}
+                        </DialogTitle>
+                        <DialogDescription>
+                            <div>Hello /berry/firmness/{firmnessId}/modal!</div>
+                        </DialogDescription>
+                    </DialogHeader>
+                </DialogContent>
+            </DialogPortal>
+        </Dialog>
+    );
+}

--- a/app/routes/berry_/firmness.$firmnessId_.modal.tsx
+++ b/app/routes/berry_/firmness.$firmnessId_.modal.tsx
@@ -1,15 +1,15 @@
 import { getBerryFirmnessQueryOptions } from "@/features/poke-berry-firmness/api/get-firmness";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import {
     Dialog,
     DialogContent,
-    DialogOverlay,
     DialogPortal,
     DialogDescription,
     DialogHeader,
     DialogTitle,
 } from "@/components/ui/dialog";
 import useBerryFirmnessQuery from "@/features/poke-berry-firmness/hooks/use-berry-firmness";
+import { Button } from "@/components/ui/button";
 
 export const Route = createFileRoute("/berry/firmness/$firmnessId/modal")({
     loader: ({ context: { queryClient }, params: { firmnessId } }) =>
@@ -31,14 +31,22 @@ function BerryFirmnessModal() {
             }}
         >
             <DialogPortal>
-                <DialogOverlay />
                 <DialogContent>
                     <DialogHeader>
                         <DialogTitle className="capitalize">
                             {berryFirmnessQuery.data.name}
                         </DialogTitle>
                         <DialogDescription>
-                            <div>Hello /berry/firmness/{firmnessId}/modal!</div>
+                            <div className="flex justify-center align-middle mx-auto">
+                                <Button asChild variant="link">
+                                    <Link
+                                        to="/berry/firmness/$firmnessId"
+                                        params={{ firmnessId }}
+                                    >
+                                        Berries of this firmness?
+                                    </Link>
+                                </Button>
+                            </div>
                         </DialogDescription>
                     </DialogHeader>
                 </DialogContent>

--- a/app/routes/berry_/firmness.index.tsx
+++ b/app/routes/berry_/firmness.index.tsx
@@ -1,0 +1,33 @@
+import { getBerryFirmnessInfiniteQueryOptions } from "@/features/poke-berry-firmness/api/list-firmness";
+import { createFileRoute } from "@tanstack/react-router";
+import FirmnessGrid from "@/features/poke-berry-firmness/components/firmness-grid";
+import type { FirmnessGridProps } from "@/features/poke-berry-firmness/components/firmness-grid";
+import { TypographyH1 } from "@/components/typography/headings";
+
+export const Route = createFileRoute("/berry/firmness/")({
+    loader: ({ context: { queryClient } }) =>
+        queryClient.ensureInfiniteQueryData(
+            getBerryFirmnessInfiniteQueryOptions,
+        ),
+    component: () => <BerryFirmnessIndex />,
+});
+
+function BerryFirmnessIndex() {
+    return (
+        <div>
+            <TypographyH1>Hello /_berry/berry/firmness/!</TypographyH1>
+            <FirmnessGrid
+                to="/berry/firmness/$firmnessId/modal"
+                paramName="firmnessId"
+                mask={(firmnessId) =>
+                    ({
+                        to: "/berry/firmness/$firmnessId",
+                        params: { firmnessId },
+                    }) as ReturnType<
+                        Exclude<FirmnessGridProps["mask"], undefined>
+                    >
+                }
+            />
+        </div>
+    );
+}

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -1,3 +1,10 @@
+import type {
+    DefinedInitialDataInfiniteOptions,
+    QueryOptions,
+    UndefinedInitialDataInfiniteOptions,
+    DefaultError,
+    InfiniteData,
+} from "@tanstack/react-query";
 import { z } from "zod";
 
 export type PaginationProps = {
@@ -15,16 +22,6 @@ export type PokeApiReference<TPokeType extends string> = {
     name: string;
     url: PokeExactEndpoint<TPokeType>;
 };
-
-export interface PokePaginationResult<
-    T extends object,
-    SPokeType extends string,
-> {
-    count: number;
-    next: PokeListEndpoint<SPokeType> | null;
-    previous: PokeListEndpoint<SPokeType> | null;
-    results: T[];
-}
 
 export const pokeListEndpointZ = <T extends string>(
     pokeCategory: T,
@@ -49,3 +46,54 @@ export const pokeExactEndpointZ = <T extends string>(
             "g",
         ).test(val as string);
     }) satisfies z.ZodType<PokeExactEndpoint<T>>;
+export interface PokePaginationResult<
+    T extends object,
+    SPokeType extends string,
+> {
+    count: number;
+    next: PokeListEndpoint<SPokeType> | null;
+    previous: PokeListEndpoint<SPokeType> | null;
+    results: T[];
+}
+
+export const pokePaginationResultZ = <
+    T extends z.ZodType,
+    SPokeCategory extends string,
+>(
+    pokeType: T,
+    pokeCategory: SPokeCategory,
+): z.ZodType<PokePaginationResult<z.infer<T>, SPokeCategory>> =>
+    // @ts-expect-error - god knows why TS thinks that required params are optional
+    z.object({
+        count: z.number(),
+        next: pokeListEndpointZ(pokeCategory).nullable(),
+        previous: pokeListEndpointZ(pokeCategory).nullable(),
+        results: z.array(pokeType),
+    });
+
+export interface ExtraQueryOptionsT<
+    TFnData,
+    TQueryKey extends readonly unknown[],
+> extends Omit<
+        QueryOptions<TFnData, DefaultError, TFnData, TQueryKey>,
+        "queryKey" | "queryFn"
+    > {}
+
+export interface ExtraInfiniteQueryOptionsT<
+    TFnData,
+    TQueryKey extends readonly unknown[],
+> extends Omit<
+        DefinedInitialDataInfiniteOptions<
+            TFnData,
+            DefaultError,
+            InfiniteData<TFnData>,
+            TQueryKey
+        > &
+            UndefinedInitialDataInfiniteOptions<
+                TFnData,
+                DefaultError,
+                InfiniteData<TFnData>,
+                TQueryKey
+            >,
+        "queryKey" | "queryFn"
+    > {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
+                "@radix-ui/react-dialog": "^1.1.2",
                 "@radix-ui/react-dropdown-menu": "^2.1.2",
                 "@radix-ui/react-label": "^2.1.0",
                 "@radix-ui/react-slot": "^1.1.0",
@@ -1659,6 +1660,42 @@
             },
             "peerDependenciesMeta": {
                 "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-dialog": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
+            "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-context": "1.1.1",
+                "@radix-ui/react-dismissable-layer": "1.1.1",
+                "@radix-ui/react-focus-guards": "1.1.1",
+                "@radix-ui/react-focus-scope": "1.1.0",
+                "@radix-ui/react-id": "1.1.0",
+                "@radix-ui/react-portal": "1.1.2",
+                "@radix-ui/react-presence": "1.1.1",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-slot": "1.1.0",
+                "@radix-ui/react-use-controllable-state": "1.1.0",
+                "aria-hidden": "^1.1.1",
+                "react-remove-scroll": "2.6.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
                     "optional": true
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
                 "@tanstack/start": "^1.58.16",
                 "class-variance-authority": "^0.7.0",
                 "clsx": "^2.1.1",
+                "embla-carousel-autoplay": "^8.3.0",
+                "embla-carousel-react": "^8.3.0",
                 "lucide-react": "^0.447.0",
                 "pokemon-sprites": "github:PokeAPI/sprites",
                 "react": "^18.3.1",
@@ -5410,6 +5412,43 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.32.tgz",
             "integrity": "sha512-M+7ph0VGBQqqpTT2YrabjNKSQ2fEl9PVx6AK3N558gDH9NO8O6XN9SXXFWRo9u9PbEg/bWq+tjXQr+eXmxubCw==",
             "license": "ISC"
+        },
+        "node_modules/embla-carousel": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.3.0.tgz",
+            "integrity": "sha512-Ve8dhI4w28qBqR8J+aMtv7rLK89r1ZA5HocwFz6uMB/i5EiC7bGI7y+AM80yAVUJw3qqaZYK7clmZMUR8kM3UA==",
+            "license": "MIT"
+        },
+        "node_modules/embla-carousel-autoplay": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.3.0.tgz",
+            "integrity": "sha512-h7DFJLf9uQD+XDxr1NwA3/oFIjsnj/iED2RjET5u6/svMec46IbF1CYPhmB5Q/1Fc0WkcvhPpsEsrtVXQLxNzA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "embla-carousel": "8.3.0"
+            }
+        },
+        "node_modules/embla-carousel-react": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.3.0.tgz",
+            "integrity": "sha512-P1FlinFDcIvggcErRjNuVqnUR8anyo8vLMIH8Rthgofw7Nj8qTguCa2QjFAbzxAUTQTPNNjNL7yt0BGGinVdFw==",
+            "license": "MIT",
+            "dependencies": {
+                "embla-carousel": "8.3.0",
+                "embla-carousel-reactive-utils": "8.3.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
+            }
+        },
+        "node_modules/embla-carousel-reactive-utils": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.3.0.tgz",
+            "integrity": "sha512-EYdhhJ302SC4Lmkx8GRsp0sjUhEN4WyFXPOk0kGu9OXZSRMmcBlRgTvHcq8eKJE1bXWBsOi1T83B+BSSVZSmwQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "embla-carousel": "8.3.0"
+            }
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
         "@tanstack/start": "^1.58.16",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "embla-carousel-autoplay": "^8.3.0",
+        "embla-carousel-react": "^8.3.0",
         "lucide-react": "^0.447.0",
         "pokemon-sprites": "github:PokeAPI/sprites",
         "react": "^18.3.1",


### PR DESCRIPTION
- **add: composable pagination zod schema**
- **add: api calls for berry-firmness**
- **add: hooks to use api calls for berry-firmness**
- **fix: naming and typing of functions/hooks**
- **add: component to display the grid of berry firmness**
- **add: berry-firmness routes, links to default Hello pages**
- **add: shadcn component for carousel**
- **add: dev only component to show tailwind screen size**
- **fix: add missing berry image export**
- **add: component to display the reference details of a berry**
- **add: component to display the berries of a firmness type in a carousel**
- **update: use carousel component on firmness detail page**
- **update: berry firmnesss modal contains link to more info**
